### PR TITLE
feat: allow keep not nullable fields not nullable

### DIFF
--- a/pydantic_partial/_compat.py
+++ b/pydantic_partial/_compat.py
@@ -15,7 +15,6 @@ if PYDANTIC_V1:  # pragma: no cover
     from pydantic.fields import ModelField  # type: ignore
 
     NULLABLE_KWARGS = {"nullable": True}
-    OPTIONAL_KWARGS = {"default": "<undefined>"}
 
     class PydanticCompat:  # type: ignore
         model_class: type[pydantic.BaseModel]
@@ -48,7 +47,6 @@ if PYDANTIC_V1:  # pragma: no cover
 
 elif PYDANTIC_V2:  # pragma: no cover
     NULLABLE_KWARGS = {"json_schema_extra": {"nullable": True}}
-    OPTIONAL_KWARGS = {"json_schema_extra": {"default": "<undefined>"}}
 
     class PydanticCompat:  # type: ignore
         model_class: type[pydantic.BaseModel]

--- a/pydantic_partial/_compat.py
+++ b/pydantic_partial/_compat.py
@@ -15,6 +15,7 @@ if PYDANTIC_V1:  # pragma: no cover
     from pydantic.fields import ModelField  # type: ignore
 
     NULLABLE_KWARGS = {"nullable": True}
+    OPTIONAL_KWARGS = {"default": "<undefined>"}
 
     class PydanticCompat:  # type: ignore
         model_class: type[pydantic.BaseModel]
@@ -47,6 +48,7 @@ if PYDANTIC_V1:  # pragma: no cover
 
 elif PYDANTIC_V2:  # pragma: no cover
     NULLABLE_KWARGS = {"json_schema_extra": {"nullable": True}}
+    OPTIONAL_KWARGS = {"json_schema_extra": {"default": "<undefined>"}}
 
     class PydanticCompat:  # type: ignore
         model_class: type[pydantic.BaseModel]

--- a/pydantic_partial/partial.py
+++ b/pydantic_partial/partial.py
@@ -30,7 +30,7 @@ from typing import Any, Optional, TypeVar, Union, cast, get_args, get_origin
 
 import pydantic
 
-from ._compat import NULLABLE_KWARGS, PydanticCompat
+from ._compat import NULLABLE_KWARGS, OPTIONAL_KWARGS, PydanticCompat
 
 SelfT = TypeVar("SelfT", bound=pydantic.BaseModel)
 ModelSelfT = TypeVar("ModelSelfT", bound="PartialModelMixin")
@@ -132,6 +132,7 @@ def create_partial_model(
                 if use_undefined is False:
                     default_value = None
                     new_field_annotation = Optional[field_annotation]
+                    partial_kwargs = NULLABLE_KWARGS
                 else:
                     if use_undefined is True:
                         default_value = UNDEFINED
@@ -139,6 +140,7 @@ def create_partial_model(
                         default_value = use_undefined
 
                     new_field_annotation = field_annotation
+                    partial_kwargs = OPTIONAL_KWARGS
 
                 optional_fields[field_name] = (
                     new_field_annotation,
@@ -146,7 +148,7 @@ def create_partial_model(
                         field_info,
                         default=default_value,  # Set default value
                         default_factory=None,  # Remove default_factory if set
-                        **NULLABLE_KWARGS,  # For API usage: set field as nullable
+                        **partial_kwargs,  # For API usage: set field as nullable
                     ),
                 )
         elif recursive or sub_fields_requested:

--- a/pydantic_partial/partial.py
+++ b/pydantic_partial/partial.py
@@ -30,7 +30,7 @@ from typing import Any, Optional, TypeVar, Union, cast, get_args, get_origin
 
 import pydantic
 
-from ._compat import NULLABLE_KWARGS, OPTIONAL_KWARGS, PydanticCompat
+from ._compat import NULLABLE_KWARGS, PydanticCompat
 
 SelfT = TypeVar("SelfT", bound=pydantic.BaseModel)
 ModelSelfT = TypeVar("ModelSelfT", bound="PartialModelMixin")
@@ -128,7 +128,10 @@ def create_partial_model(
 
         # Construct new field definition
         if field_name in fields_:
-            if model_compat.is_model_field_info_required(field_info):
+            if (
+                model_compat.is_model_field_info_required(field_info)
+                or use_undefined is not False
+            ):
                 if use_undefined is False:
                     default_value = None
                     new_field_annotation = Optional[field_annotation]
@@ -140,7 +143,7 @@ def create_partial_model(
                         default_value = use_undefined
 
                     new_field_annotation = field_annotation
-                    partial_kwargs = OPTIONAL_KWARGS
+                    partial_kwargs = {}
 
                 optional_fields[field_name] = (
                     new_field_annotation,

--- a/tests/test_partial.py
+++ b/tests/test_partial.py
@@ -323,17 +323,14 @@ def test_not_nullable_partial_produces_correct_json_schema():
     assert SomethingPartial.model_json_schema() == {
         'properties': {
             'age': {
-                'default': '<undefined>',
                 'title': 'Age',
                 'type': 'integer'
             },
             'already_optional': {
-                'default': None,
                 'title': 'Already Optional',
                 'type': 'null'
             },
             'test_name': {
-                'default': '<undefined>',
                 'something_else': True,
                 'title': 'TEST Name',
                 'type': 'string'

--- a/tests/test_partial.py
+++ b/tests/test_partial.py
@@ -316,3 +316,29 @@ def test_not_nullable_partial_with_custom_default():
         "age": 42,
     }
     assert model.name == "custom_default"
+
+
+def test_not_nullable_partial_produces_correct_json_schema():
+    SomethingPartial = Something.model_as_partial(use_undefined=True)
+    assert SomethingPartial.model_json_schema() == {
+        'properties': {
+            'age': {
+                'default': '<undefined>',
+                'title': 'Age',
+                'type': 'integer'
+            },
+            'already_optional': {
+                'default': None,
+                'title': 'Already Optional',
+                'type': 'null'
+            },
+            'test_name': {
+                'default': '<undefined>',
+                'something_else': True,
+                'title': 'TEST Name',
+                'type': 'string'
+            }
+        },
+        'title': 'SomethingPartial',
+        'type': 'object'
+    }


### PR DESCRIPTION
Currently, `pydantic-partial` allows to set `None` for not nullable fields, which brakes the validate logic on the FastAPI endpoint.

This PR provides a new parameter `use_undefined`, to use `UNDEFINED` value as default instead of `None`, and doesn't make fields nullable.

Please take a look on the test cases.

Use case:
```python
class UserUpdateSchema(PartialModelMixin, pydantic.BaseModel):
    first_name: str
    second_name: str | None
  

@router.put()
def update_me(user: AuthUser, payload: UserUpdateSchema):
    user.set_values(payload.model_dump())

@router.patch()
def partial_update_me(user: AuthUser, payload: UserUpdateSchema.model_as_partial(
    use_undefined=True, # without this flag `first_name` can be set to `None` which is wrong
)):
    user.set_values(payload.model_dump(exclude_unset=True))

```