### PR TITLE
Allow to keep the types as they were and just add a default value

### DIFF
--- a/pydantic_partial/partial.py
+++ b/pydantic_partial/partial.py
@@ -41,6 +41,7 @@ def create_partial_model(
     base_cls: type[SelfT],
     *fields: str,
     recursive: bool = False,
+    optional: bool = True,
 ) -> type[SelfT]:
     # Convert one type to being partial - if possible
     def _partial_annotation_arg(field_name_: str, field_annotation: type) -> type:
@@ -104,8 +105,15 @@ def create_partial_model(
         # Construct new field definition
         if field_name in fields_:
             if model_compat.is_model_field_info_required(field_info):
+                # Allow to keep the types as they were and just add a
+                # default value
+                if optional:
+                    annotation = Optional[field_annotation]
+                else:
+                    annotation = field_annotation
+
                 optional_fields[field_name] = (
-                    Optional[field_annotation],
+                    annotation,
                     model_compat.copy_model_field_info(
                         field_info,
                         default=None,  # Set default to None


### PR DESCRIPTION
It's still possible to omit all unchanged fields in PATCH requests, but for fields that are given Pydantic will reject data that specifies an explicit null for fields that aren't optional in the full model.

This is useful when using the package with SQLModel. Without this feature the client could try to assign a NULL value to a column with a NOT NULL constraint, which would raise an IntegrityError.