### PR TITLE
include license file in distributions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.10.0"
 description = "Create partial models from your pydantic models. Partial models may allow None for certain or all fields."
 authors = [{ name = "TEAM23 GmbH", email = "info@team23.de" }]
 license = "MIT"
+license-files = ["LICENSE"]
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [


### PR DESCRIPTION
Congratulations on 0.10.0 :tada:

This little change explicitly tells the build backend to include `LICENSE` in the `.tar.gz` and `.whl` distributions.

Motivation: packaging downstream on [conda-forge](https://github.com/conda-forge/pydantic-partial-feedstock/pull/6) which requires a license file.

Future work could involve:
- including the `tests` folder in the sdist (the conda-forge build was already getting the github tag tarball for these, but the canonical `.tar.gz` is generally preferred)
- using a `uv` or third-party tool to check sdist/wheel before they go out  

Thanks!